### PR TITLE
[Sage-800] Added CLI metrics publish tool

### DIFF
--- a/ROOTFS/usr/bin/waggle-publish-metric
+++ b/ROOTFS/usr/bin/waggle-publish-metric
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import argparse
+import time
+import base64
+import json
+from typing import NamedTuple, Any
+from pathlib import Path
+import re
+import sys
+
+
+# TODO consolidate this with pywaggle bit. would be nice to not have to install pywaggle
+# in base image
+class Message(NamedTuple):
+    name: str
+    value: Any
+    timestamp: int
+    meta: dict
+
+
+def dump_message(msg: Message) -> bytes:
+    payload = {
+        "name": msg.name,
+        "ts": msg.timestamp,
+        "meta": msg.meta,
+        "val": msg.value,
+    }
+
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def infer_type(s):
+    for mapper in [int, float]:
+        try:
+            return mapper(s)
+        except ValueError:
+            continue
+    # always fallback to string
+    return s
+
+type_mapper = {
+    "": infer_type, 
+    "int": int,
+    "float": float,
+    "str": str,
+}
+
+def build_meta_dict(metalist):
+    meta = {}
+    for s in metalist:
+        k, v = s.split("=", 1)
+        meta[k] = v
+    return meta
+
+
+def isvalidname(s):
+    return re.match(r"[A-Za-z0-9_.-]+$", s) is not None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", default="/run/metrics", type=Path, help="path used to store metrics data")
+    parser.add_argument("--time", default=time.time_ns(), type=int, help="timestamp to use")
+    parser.add_argument("--meta", action="append", default=[], help="metadata tag")
+    parser.add_argument("--type", default="", help="value type. (infer from value by default)")
+    parser.add_argument("name", help="metric name")
+    parser.add_argument("value", help="metric value")
+    args = parser.parse_args()
+
+    if not isvalidname(args.name):
+        raise ValueError("invalid name")
+
+    value = type_mapper[args.type](args.value)
+    meta = build_meta_dict(args.meta)
+
+    # write to ".ts" temp file then rename to "ts" after write is done
+    publish_time = time.time_ns()
+    tmpfile = Path(args.data_dir, args.name, "." + str(publish_time))
+    outfile = Path(tmpfile.parent, str(publish_time))
+
+    tmpfile.parent.mkdir(parents=True, exist_ok=True)
+    tmpfile.write_text(dump_message(Message(
+        name=args.name,
+        value=value,
+        timestamp=args.time,
+        meta=meta,
+    )))
+
+    tmpfile.rename(outfile)
+
+
+if __name__ == "__main__":
+    main()

--- a/ROOTFS/usr/bin/waggle-publish-metric
+++ b/ROOTFS/usr/bin/waggle-publish-metric
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 import argparse
 import time
-import base64
 import json
 from typing import NamedTuple, Any
 from pathlib import Path
 import re
-import sys
 from uuid import uuid4
 
+# Backwards compatibility hack for time_ns func in Python < 3.7
+# See: https://docs.python.org/3/library/time.html#time.process_time_ns
 try:
     from time import time_ns
 except Exception:

--- a/ROOTFS/usr/bin/waggle-publish-metric
+++ b/ROOTFS/usr/bin/waggle-publish-metric
@@ -7,6 +7,13 @@ from typing import NamedTuple, Any
 from pathlib import Path
 import re
 import sys
+from uuid import uuid4
+
+try:
+    from time import time_ns
+except Exception:
+    def time_ns():
+        return int(time.time() * 1e9)
 
 
 # TODO consolidate this with pywaggle bit. would be nice to not have to install pywaggle
@@ -60,7 +67,7 @@ def isvalidname(s):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--data-dir", default="/run/metrics", type=Path, help="path used to store metrics data")
-    parser.add_argument("--time", default=time.time_ns(), type=int, help="timestamp to use")
+    parser.add_argument("--time", default=time_ns(), type=int, help="timestamp to use")
     parser.add_argument("--meta", action="append", default=[], help="metadata tag")
     parser.add_argument("--type", default="", help="value type. (infer from value by default)")
     parser.add_argument("name", help="metric name")
@@ -74,9 +81,10 @@ def main():
     meta = build_meta_dict(args.meta)
 
     # write to ".ts" temp file then rename to "ts" after write is done
-    publish_time = time.time_ns()
-    tmpfile = Path(args.data_dir, args.name, "." + str(publish_time))
-    outfile = Path(tmpfile.parent, str(publish_time))
+    # TODO decide "level of randomness" needed to suffix.
+    basename = str(args.time) + "-" + uuid4().hex[:8]
+    tmpfile = Path(args.data_dir, args.name, "." + basename)
+    outfile = Path(tmpfile.parent, basename)
 
     tmpfile.parent.mkdir(parents=True, exist_ok=True)
     tmpfile.write_text(dump_message(Message(


### PR DESCRIPTION
Added `waggle-publish-metric` tool which allows low level services can use to queue up metrics to be scraped by the metrics agent.

Intended interface is:

```sh
waggle-publish-metric name value [--time timestamp_ns] --meta k1=v1 --meta k2=v2 ...
```

The tool stores metrics on the FS in the form:

```
$DATADIR/metric-name/metric-timestamp-randsuffix
```

This is scraped and cleaned up by the metrics agent.