### PR TITLE
[SAGE-1068] Using wagglemsg in waggle-publish-metric.

### DIFF
--- a/ROOTFS/usr/bin/waggle-publish-metric
+++ b/ROOTFS/usr/bin/waggle-publish-metric
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 import argparse
 import time
-import json
-from typing import NamedTuple, Any
 from pathlib import Path
 import re
 from uuid import uuid4
+import wagglemsg
 
 # Backwards compatibility hack for time_ns func in Python < 3.7
 # See: https://docs.python.org/3/library/time.html#time.process_time_ns
@@ -14,26 +13,6 @@ try:
 except Exception:
     def time_ns():
         return int(time.time() * 1e9)
-
-
-# TODO consolidate this with pywaggle bit. would be nice to not have to install pywaggle
-# in base image
-class Message(NamedTuple):
-    name: str
-    value: Any
-    timestamp: int
-    meta: dict
-
-
-def dump_message(msg: Message) -> bytes:
-    payload = {
-        "name": msg.name,
-        "ts": msg.timestamp,
-        "meta": msg.meta,
-        "val": msg.value,
-    }
-
-    return json.dumps(payload, separators=(",", ":"))
 
 
 def infer_type(s):
@@ -87,7 +66,7 @@ def main():
     outfile = Path(tmpfile.parent, basename)
 
     tmpfile.parent.mkdir(parents=True, exist_ok=True)
-    tmpfile.write_text(dump_message(Message(
+    tmpfile.write_text(wagglemsg.dump(wagglemsg.Message(
         name=args.name,
         value=value,
         timestamp=args.time,


### PR DESCRIPTION
We're replacing the duplicated message code with the wagglemsg module.